### PR TITLE
Derive std::error::Error implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 bincode = "1.3.3"
 ahash = { version = "0.8.0" }
 fancy-regex = "0.11.0"
+thiserror = "1.0.50"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -37,7 +37,7 @@ use self::{
 pub mod grammar;
 pub mod lexer;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub struct CompileError {
     line_num: usize,
     line_pos: usize,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -58,7 +58,7 @@ pub enum Variable {
     Array(Arc<Vec<Variable>>),
 }
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum RuntimeError {
     TooManyIncludes,
     InvalidInstruction(Invalid),


### PR DESCRIPTION
Hi, I played around with the crate and noticed that `anyhow` could not propagate the errors (without stringifying), due to missing implementations of `std::error::Error`.